### PR TITLE
Fix docker build documentation

### DIFF
--- a/docker/Dockerfile_binary
+++ b/docker/Dockerfile_binary
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cudagl:10.0-devel-ubuntu18.04
+ARG BASE_IMAGE=nvidia/cudagl:10.2-devel-ubuntu18.04
 FROM $BASE_IMAGE
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/build_airsim_image.py
+++ b/docker/build_airsim_image.py
@@ -14,7 +14,7 @@ def build_docker_image(args):
     dockerfile = 'Dockerfile_source'
     if args.source:
         if not args.base_image:
-            args.base_image = "adamrehn/ue4-engine:4.19.2-cudagl10.0"
+            args.base_image = "adamrehn/ue4-engine:4.19.2-cudagl10.2"
         target_image_tag = args.base_image.split(":")[1] # take tag from base image
         if not args.target_image:
             args.target_image = 'airsim_source' + ':' + target_image_tag
@@ -22,7 +22,7 @@ def build_docker_image(args):
     else:
         dockerfile = 'Dockerfile_binary'
         if not args.base_image:
-            args.base_image = "nvidia/cudagl:10.0-devel-ubuntu18.04"
+            args.base_image = "nvidia/cudagl:10.2-devel-ubuntu18.04"
         target_image_tag = args.base_image.split(":")[1] # take tag from base image
         if not args.target_image:
             args.target_image = 'airsim_binary' + ':' + target_image_tag

--- a/docs/docker_ubuntu.md
+++ b/docs/docker_ubuntu.md
@@ -7,7 +7,7 @@ We've two options for docker. You can either build an image for running [airsim 
 
 #### Build the docker image
 - Below are the default arguments.
-  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 with CUDA 10.0.
+  `--base_image`: This is image over which we'll install airsim. We've tested on Ubuntu 18.04 with CUDA 10.2.
    You can specify any [NVIDIA cudagl](https://hub.docker.com/r/nvidia/cudagl/) at your own risk.
    `--target_image` is the desired name of your docker image.
    Defaults to `airsim_binary` with same tag as the base image
@@ -15,8 +15,8 @@ We've two options for docker. You can either build an image for running [airsim 
 ```bash
 $ cd Airsim/docker;
 $ python build_airsim_image.py \
-   --base_image=nvidia/cudagl:10.0-devel-ubuntu18.04 \
-   --target_image=airsim_binary:10.0-devel-ubuntu18.04
+   --base_image=nvidia/cudagl:10.2-devel-ubuntu18.04 \
+   --target_image=airsim_binary:10.2-devel-ubuntu18.04
 ```
 
 - Verify you have an image by:
@@ -41,9 +41,9 @@ Modify it to fetch the specific binary required.
    $ ./run_airsim_image_binary.sh DOCKER_IMAGE_NAME UNREAL_BINARY_SHELL_SCRIPT UNREAL_BINARY_ARGUMENTS -- headless
 ```
 
-   For Blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.0-devel-ubuntu18.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
+   For Blocks, you can do a `$ ./run_airsim_image_binary.sh airsim_binary:10.2-devel-ubuntu18.04 Blocks/Blocks.sh -windowed -ResX=1080 -ResY=720`
 
-   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.0-devel-ubuntu18.04`
+   * `DOCKER_IMAGE_NAME`: Same as `target_image` parameter in previous step. By default, enter `airsim_binary:10.2-devel-ubuntu18.04`
    * `UNREAL_BINARY_SHELL_SCRIPT`: for Blocks enviroment, it will be `Blocks/Blocks.sh`
    * [`UNREAL_BINARY_ARGUMENTS`](https://docs.unrealengine.com/en-us/Programming/Basics/CommandLineArguments):
       For airsim, most relevant would be `-windowed`, `-ResX`, `-ResY`. Click on link to see all options.


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

<!-- Fixes: # -->
<!-- Fixes: # -->

## About

Folling the current [docs](https://github.com/microsoft/AirSim/blob/caa13182328e866564c09fdeebca89ba024bc323/docs/docker_ubuntu.md) to build the docker image for AirSim you get the error

```
GPG error:
https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64
InRelease: The following signatures couldn't be verified because the public key
is not available: NO_PUBKEY A4B469963BF863CC
```

That's because the image [nvidia/cudagl:10.0-devel-ubuntu18.04](https://hub.docker.com/layers/cudagl/nvidia/cudagl/10.0-devel-ubuntu18.04/images/sha256-391c3392b841f9ab599a655e138cf938287ce8eb001dc9f8795b5fadcf80f1cb?context=explore) has expired signing keys for `apt` since April 27, 2022[^1]. The maintainer of this image only updated the 10.2 version ([nvidia/cudagl:10.2-devel-ubuntu18.04](https://hub.docker.com/layers/cudagl/nvidia/cudagl/10.2-devel-ubuntu18.04/images/sha256-cf5322ff78bb8e71b0fb3beb334c7f88fb53689d2297db52f5f2a66750ac9dad?context=explore)).
Which I have tested to work just fine with AirSim.

[^1]: [Updating the CUDA Linux GPG Repository Key](https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/)

## How Has This Been Tested?

Followed the exact instructions from the [docs](https://github.com/microsoft/AirSim/blob/caa13182328e866564c09fdeebca89ba024bc323/docs/docker_ubuntu.md) to build the docker image but instead of using the `cudagl:10.0`, I used the image `cudagl:10.2`. I got AirSim up and running, just like it was running when the `cudagl:10.0` version was used.

## Screenshots (if appropriate):

